### PR TITLE
Free GCHandle when unregistering Callbacks and CallResults

### DIFF
--- a/sources/NewBlood.Interop.Steamworks/CCallResultHandle.cs
+++ b/sources/NewBlood.Interop.Steamworks/CCallResultHandle.cs
@@ -65,7 +65,7 @@ public unsafe abstract class CCallResultHandle : IDisposable
 
         if (_gcHandle.IsAllocated)
         {
-            _gcHandle.Target = null;
+            _gcHandle.Free();
         }
     }
 

--- a/sources/NewBlood.Interop.Steamworks/CCallbackHandle{T}.cs
+++ b/sources/NewBlood.Interop.Steamworks/CCallbackHandle{T}.cs
@@ -80,7 +80,7 @@ public unsafe sealed class CCallbackHandle<T> : CCallbackHandle
 
         if (_gcHandle.IsAllocated)
         {
-            _gcHandle.Target = null;
+            _gcHandle.Free();
         }
     }
 


### PR DESCRIPTION
Avoids a GCHandle memory leak when a Callback or CallResult is registered, unregistered, discarded and then left for garbage collection without calling Dispose.

This results in potentially multiple GCHandles being allocated for a single Callback or CallResult. An alternative solution that only allocates once would be to implement a SafeGCHandle class, but this is expected to be a very rare use case for Callbacks and CallResults, so it would be a solution of questionable worth.