### PR TITLE
Use generated HServerListRequest helper type

### DIFF
--- a/generation/remap-transparent.rsp
+++ b/generation/remap-transparent.rsp
@@ -11,6 +11,7 @@ DepotId_t=uint;Typedef
 FriendsGroupID_t=short;Typedef
 HAuthTicket=uint;Typedef
 HHTMLBrowser=uint;Typedef
+HServerListRequest=void*;Handle
 HServerQuery=int;Typedef
 HSteamListenSocket=uint;Typedef
 HSteamNetConnection=uint;Typedef

--- a/generation/remap-types.rsp
+++ b/generation/remap-types.rsp
@@ -1,4 +1,3 @@
 --remap
-HServerListRequest=HServerListRequest
 uint64_gameid=CGameID
 uint64_steamid=CSteamID

--- a/sources/NewBlood.Interop.Steamworks/Generated/helper_types/HServerListRequest.cs
+++ b/sources/NewBlood.Interop.Steamworks/Generated/helper_types/HServerListRequest.cs
@@ -71,7 +71,7 @@ public readonly unsafe partial struct HServerListRequest : IComparable, ICompara
 
     public int CompareTo(object? obj)
     {
-        if (obj is HServerListRequest other)
+            if (obj is HServerListRequest other)
         {
             return CompareTo(other);
         }
@@ -79,33 +79,15 @@ public readonly unsafe partial struct HServerListRequest : IComparable, ICompara
         return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of HServerListRequest.");
     }
 
-    public int CompareTo(HServerListRequest other)
-    {
-        if (sizeof(nint) == 4)
-            return ((uint)Value).CompareTo((uint)other.Value);
-        else
-            return ((ulong)Value).CompareTo((ulong)other.Value);
-    }
+    public int CompareTo(HServerListRequest other) => ((nuint)(Value)).CompareTo((nuint)(other.Value));
 
     public override bool Equals(object? obj) => (obj is HServerListRequest other) && Equals(other);
 
-    public bool Equals(HServerListRequest other) => ((nuint)Value) == ((nuint)other.Value);
+    public bool Equals(HServerListRequest other) => ((nuint)(Value)).Equals((nuint)(other.Value));
 
-    public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    public override int GetHashCode() => ((nuint)(Value)).GetHashCode();
 
-    public override string ToString()
-    {
-        if (sizeof(nint) == 4)
-            return ((uint)Value).ToString("X8");
-        else
-            return ((ulong)Value).ToString("X16");
-    }
+    public override string ToString() => ((nuint)(Value)).ToString((sizeof(nint) == 4) ? "X8" : "X16");
 
-    public string ToString(string? format, IFormatProvider? formatProvider)
-    {
-        if (sizeof(nint) == 4)
-            return ((uint)Value).ToString(format, formatProvider);
-        else
-            return ((ulong)Value).ToString(format, formatProvider);
-    }
+    public string ToString(string? format, IFormatProvider? formatProvider) => ((nuint)(Value)).ToString(format, formatProvider);
 }

--- a/sources/NewBlood.Interop.Steamworks/UIntPtrExtensions.cs
+++ b/sources/NewBlood.Interop.Steamworks/UIntPtrExtensions.cs
@@ -1,0 +1,32 @@
+#if !NET5_0_OR_GREATER
+using System;
+
+namespace NewBlood.Interop.Steamworks;
+
+internal static unsafe class UIntPtrExtensions
+{
+    public static int CompareTo(this nuint value, nuint other)
+    {
+        if (sizeof(nuint) == sizeof(uint))
+            return ((uint)value).CompareTo((uint)other);
+        else
+            return ((ulong)value).CompareTo(other);
+    }
+
+    public static string ToString(this nuint value, string? format)
+    {
+        if (sizeof(nuint) == sizeof(uint))
+            return ((uint)value).ToString(format);
+        else
+            return ((ulong)value).ToString(format);
+    }
+
+    public static string ToString(this nuint value, string? format, IFormatProvider? formatProvider)
+    {
+        if (sizeof(nuint) == sizeof(uint))
+            return ((uint)value).ToString(format, formatProvider);
+        else
+            return ((ulong)value).ToString(format, formatProvider);
+    }
+}
+#endif


### PR DESCRIPTION
Removes the manual implementation of `HServerListRequest`, since the generated version now compiles under `netstandard2.1` with some polyfills.