### PR TITLE
Use AsmResolver to process export directories

### DIFF
--- a/sources/NewBlood.Interop.Steamworks.Generator/NewBlood.Interop.Steamworks.Generator.csproj
+++ b/sources/NewBlood.Interop.Steamworks.Generator/NewBlood.Interop.Steamworks.Generator.csproj
@@ -2,13 +2,13 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AsmResolver.PE" Version="5.4.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-        <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
`NewBlood.Interop.Steamworks.Generator` now uses AsmResolver to process the export directories of the Steamworks DLLs. This makes it cross-platform (generating the SDK should now be possible on Linux) and removes the use of unsafe code.