### PR TITLE
Allocate a null RTTI pointer before the CCallbackBase method table

### DIFF
--- a/sources/NewBlood.Interop.Steamworks/CCallback.cs
+++ b/sources/NewBlood.Interop.Steamworks/CCallback.cs
@@ -36,7 +36,12 @@ internal unsafe ref struct CCallback
 
     private static CCallbackBase.MethodTable* AllocateMethodTable()
     {
-        var vtable = (CCallbackBase.MethodTable*)SteamInteropHelpers.AllocateTypeAssociatedMemory(typeof(CCallback), sizeof(CCallbackBase.MethodTable));
+        var buffer = (void**)SteamInteropHelpers.AllocateTypeAssociatedMemory(typeof(CCallback), sizeof(CCallbackBase.MethodTable) + sizeof(void*));
+        var vtable = (CCallbackBase.MethodTable*)(buffer + 1);
+
+        // The first pointer in the buffer is the RTTI pointer, which precedes the vtable entries.
+        // We want it to be zeroed to ensure that any attempts to use dynamic_cast etc will crash.
+        *buffer = null;
 
     #if NET5_0_OR_GREATER
         vtable->RunCallback          = &RunCallback;


### PR DESCRIPTION
In both the MSVC and Itanium ABIs (and presumably most other C++ ABIs that support `dynamic_cast`) the vtable is preceded by a pointer to an RTTI structure.

This change will allocate space for such a pointer when allocating the `CCallback` method table, and assign its value to `null` (0). This is done in order to cause a crash instead of enabling subtle memory corruption in the event of some piece of code using a managed `CCallback` instance with `dynamic_cast` or similar functionality requiring RTTI in C++.

It should be noted that `dynamic_cast` et all have never been safe to use with `CCallback` (and Steamworks itself doesn't use them), this change simply guarantees that doing so will crash appropriately.